### PR TITLE
Small updates while testing new docs repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ local-check-links: ## Check links in markdown files locally using a docker image
 ## -- Docs targets -------------------------------------------------------------------------------------------------- ##
 .PHONY: preview-docs
 preview-docs: ## Preview the documentation site locally
-	@poetry run mkdocs serve
+	@poetry run mkdocs serve -a 0.0.0.0:7000
 
 
 .PHONY: build-docs

--- a/docs/sections/dev-guide/developer-guide.md
+++ b/docs/sections/dev-guide/developer-guide.md
@@ -1,4 +1,4 @@
-# Quick Start
+# Getting started 
 
 Antenna uses [Docker](https://docs.docker.com/get-docker/) & [Docker Compose](https://docs.docker.com/compose/install/) to run all services locally for development.
 


### PR DESCRIPTION
## Summary

Testing the new docs repo. 

- Successfully installed docs dependencies with the Makefiles and poetry
- Successfully ran docs preview with auto-refresh
- Made small update to docs, testing auto-build now
- Update preview hostname to 0.0.0.0 to allow access from hostnames other than localhost (for remote dev using VPN)
- Update preview port to not conflict with default port for Antenna API (8000->7000)